### PR TITLE
Add urls to events, fixes according to the specs, PEP8 fixes

### DIFF
--- a/ics/event.py
+++ b/ics/event.py
@@ -281,13 +281,12 @@ class Event(Component):
         """
         Returns:
             int: hash of self. Based on self.uid."""
-        ord3 = lambda x: '%.3d' % ord(x)
-        return int(''.join(map(ord3, self.uid)))
+        return int(''.join(map(lambda x: '%.3d' % ord(x), self.uid)))
 
 
-######################
-####### Inputs #######
-
+# ------------------
+# ----- Inputs -----
+# ------------------
 @Event._extracts('DTSTAMP')
 def created(event, line):
     if line:
@@ -353,8 +352,9 @@ def uid(event, line):
         event.uid = line.value
 
 
-######################
-###### Outputs #######
+# -------------------
+# ----- Outputs -----
+# -------------------
 @Event._outputs
 def o_created(event, container):
     if event.created:

--- a/ics/event.py
+++ b/ics/event.py
@@ -46,7 +46,8 @@ class Event(Component):
                  uid=None,
                  description=None,
                  created=None,
-                 location=None):
+                 location=None,
+                 url=None):
         """Instanciates a new :class:`ics.event.Event`.
 
         Args:
@@ -58,6 +59,7 @@ class Event(Component):
             description (string)
             created (Arrow-compatible)
             location (string)
+            url (string)
 
         Raises:
             ValueError: if `end` and `duration` are specified at the same time
@@ -71,6 +73,7 @@ class Event(Component):
         self.description = description
         self.created = get_arrow(created)
         self.location = location
+        self.url = url
         self._unused = Container(name='VEVENT')
 
         self.name = name
@@ -337,6 +340,11 @@ def location(event, line):
     event.location = unescape_string(line.value) if line else None
 
 
+@Event._extracts('URL')
+def url(event, line):
+    event.url = unescape_string(line.value) if line else None
+
+
 # TODO : make uid required ?
 # TODO : add option somewhere to ignore some errors
 @Event._extracts('UID')
@@ -396,6 +404,12 @@ def o_description(event, container):
 def o_location(event, container):
     if event.location:
         container.append(ContentLine('LOCATION', value=escape_string(event.location)))
+
+
+@Event._outputs
+def o_url(event, container):
+    if event.url:
+        container.append(ContentLine('URL', value=escape_string(event.url)))
 
 
 @Event._outputs

--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -164,8 +164,9 @@ class Calendar(Component):
         return Calendar(events)
 
 
-######################
-####### Inputs #######
+# ------------------
+# ----- Inputs -----
+# ------------------
 
 @Calendar._extracts('PRODID', required=True)
 def prodid(calendar, prodid):
@@ -225,12 +226,14 @@ def timezone(calendar, vtimezones):
 def events(calendar, lines):
     # tz=calendar._timezones gives access to the event factory to the
     # timezones list
-    event_factory = lambda x: Event._from_container(x, tz=calendar._timezones)
+    def event_factory(x):
+        return Event._from_container(x, tz=calendar._timezones)
     calendar.events = list(map(event_factory, lines))
 
 
-######################
-###### Outputs #######
+# -------------------
+# ----- Outputs -----
+# -------------------
 
 @Calendar._outputs
 def o_prodid(calendar, container):

--- a/ics/parse.py
+++ b/ics/parse.py
@@ -24,12 +24,13 @@ class ContentLine:
     """
 
     def __eq__(self, other):
-        ret = (self.name == other.name
-               and self.params == other.params
-               and self.value == other.value)
+        ret = (self.name == other.name and
+               self.params == other.params and
+               self.value == other.value)
         return ret
 
-    __ne__ = lambda self, other: not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __init__(self, name, params={}, value=''):
         self.name = name.upper()
@@ -88,7 +89,7 @@ class ContentLine:
 class Container(list):
     """ represents one calendar object.
     Contains a list of ContentLines or Containers.
-    
+
     name: the name of the object (VCALENDAR, VEVENT etc.)
     """
 

--- a/ics/parse.py
+++ b/ics/parse.py
@@ -17,7 +17,8 @@ class ParseError(Exception):
 class ContentLine:
     """ represents one property of calender content
 
-    name:   the name of the property
+    name:   the name of the property (uppercased for consistency and
+            easier comparing)
     params: a dict of the parameters
     value:  its value
     """
@@ -31,7 +32,7 @@ class ContentLine:
     __ne__ = lambda self, other: not self.__eq__(other)
 
     def __init__(self, name, params={}, value=''):
-        self.name = name
+        self.name = name.upper()
         self.params = params
         self.value = value
 
@@ -77,7 +78,7 @@ class ContentLine:
                 raise ParseError("No '=' in line '{}'".format(line))
             pname, pvals = paramstr.split('=', 1)
             params[pname] = pvals.split(',')
-        return cls(name.upper(), params, value)
+        return cls(name, params, value)
 
     def clone(self):
         # dict(self.params) -> Make a copy of the dict

--- a/ics/utils.py
+++ b/ics/utils.py
@@ -3,18 +3,17 @@
 
 from __future__ import unicode_literals, absolute_import
 
+from arrow.arrow import Arrow
+from datetime import timedelta
 from six import PY2, PY3, StringIO, string_types, text_type, integer_types
 from six.moves import filter, map, range
-
-import arrow
-from arrow.arrow import Arrow
-tzutc = arrow.utcnow().tzinfo
 from uuid import uuid4
-
+import arrow
 import re
 
 from . import parse
-from datetime import timedelta
+
+tzutc = arrow.utcnow().tzinfo
 
 
 def remove_x(container):

--- a/tests/component.py
+++ b/tests/component.py
@@ -5,14 +5,9 @@ from ics.parse import Container, ContentLine
 from .fixture import cal2
 import copy
 
-fix1 = """BEGIN:BASETEST
-ATTR:FOOBAR
-END:BASETEST"""
+fix1 = "BEGIN:BASETEST\r\nATTR:FOOBAR\r\nEND:BASETEST"
 
-fix2 = """BEGIN:BASETEST
-ATTR:FOO
-ATTR2:BAR
-END:BASETEST"""
+fix2 = "BEGIN:BASETEST\r\nATTR:FOO\r\nATTR2:BAR\r\nEND:BASETEST"
 
 
 class TestComponent(unittest.TestCase):

--- a/tests/contentline.py
+++ b/tests/contentline.py
@@ -5,11 +5,11 @@ from ics.parse import ParseError, ContentLine
 class TestContentLine(unittest.TestCase):
 
     dataset = {
-        'haha:': ContentLine('haha'),
+        'HAHA:': ContentLine('haha'),
         ':hoho': ContentLine('', {}, 'hoho'),
-        'haha:hoho': ContentLine('haha', {}, 'hoho'),
-        'haha:hoho:hihi': ContentLine('haha', {}, 'hoho:hihi'),
-        'haha;hoho=1:hoho': ContentLine('haha', {'hoho': ['1']}, 'hoho'),
+        'HAHA:hoho': ContentLine('haha', {}, 'hoho'),
+        'HAHA:hoho:hihi': ContentLine('haha', {}, 'hoho:hihi'),
+        'HAHA;hoho=1:hoho': ContentLine('haha', {'hoho': ['1']}, 'hoho'),
         'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU':
         ContentLine(
             'RRULE',
@@ -53,11 +53,11 @@ class TestContentLine(unittest.TestCase):
         for test in self.dataset:
             expected = test
             got = str(self.dataset[test])
-            self.assertEqual(expected, got, "To string")
+            self.assertEqual(expected, got)
 
     def test_parse(self):
         self.dataset2.update(self.dataset)
         for test in self.dataset2:
             expected = self.dataset2[test]
             got = ContentLine.parse(test)
-            self.assertEqual(expected, got, "Parse")
+            self.assertEqual(expected, got)

--- a/tests/event.py
+++ b/tests/event.py
@@ -6,6 +6,8 @@ from ics.icalendar import Calendar
 from ics.parse import Container
 from .fixture import cal12, cal13, cal15, cal16
 
+CRLF = "\r\n"
+
 
 class TestEvent(unittest.TestCase):
 
@@ -47,7 +49,7 @@ class TestEvent(unittest.TestCase):
 
     def test_duration_output(self):
         e = Event(begin=0, duration=timedelta(1, 23))
-        lines = str(e).split('\n')
+        lines = str(e).splitlines()
         self.assertIn('DTSTART:19700101T000000Z', lines)
         self.assertIn('DURATION:P1DT23S', lines)
 
@@ -197,13 +199,13 @@ class TestEvent(unittest.TestCase):
         e.created = arrow.Arrow(2013, 1, 1)
         e.uid = "empty-uid"
 
-        eq = """BEGIN:VEVENT
-DTSTAMP:20130101T000000Z
-SUMMARY:Hello\\, with \\\\ spechial\\; chars and \\n newlines
-DESCRIPTION:Every\\nwhere ! Yes\\, yes !
-LOCATION:Here\\; too
-UID:empty-uid
-END:VEVENT"""
+        eq = CRLF.join(("BEGIN:VEVENT",
+                "DTSTAMP:20130101T000000Z",
+                "SUMMARY:Hello\\, with \\\\ spechial\\; chars and \\n newlines",
+                "DESCRIPTION:Every\\nwhere ! Yes\\, yes !",
+                "LOCATION:Here\\; too",
+                "UID:empty-uid",
+                "END:VEVENT"))
         self.assertEqual(str(e), eq)
 
     def test_url_input(self):

--- a/tests/event.py
+++ b/tests/event.py
@@ -214,8 +214,4 @@ END:VEVENT"""
     def test_url_output(self):
         URL = "http://example.com/pub/calendars/jsmith/mytime.ics"
         e = Event(name="Name", url=URL)
-        eq = """BEGIN:VEVENT
-SUMMARY:Name
-URL:http://example.com/pub/calendars/jsmith/mytime.ics
-END:VEVENT"""
-        self.assertEqual(str(e), eq)
+        self.assertIn("URL:"+URL, str(e).splitlines())

--- a/tests/event.py
+++ b/tests/event.py
@@ -4,7 +4,7 @@ import arrow
 from ics.event import Event
 from ics.icalendar import Calendar
 from ics.parse import Container
-from .fixture import cal12, cal13, cal15
+from .fixture import cal12, cal13, cal15, cal16
 
 
 class TestEvent(unittest.TestCase):
@@ -105,6 +105,7 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(e.description, None)
         self.assertEqual(e.created, None)
         self.assertEqual(e.location, None)
+        self.assertEqual(e.url, None)
         self.assertEqual(e._unused, Container(name='VEVENT'))
 
     def test_has_end(self):
@@ -202,5 +203,19 @@ SUMMARY:Hello\\, with \\\\ spechial\\; chars and \\n newlines
 DESCRIPTION:Every\\nwhere ! Yes\\, yes !
 LOCATION:Here\\; too
 UID:empty-uid
+END:VEVENT"""
+        self.assertEqual(str(e), eq)
+
+    def test_url_input(self):
+        c = Calendar(cal16)
+        e = c.events[0]
+        self.assertEqual(e.url, "http://example.com/pub/calendars/jsmith/mytime.ics")
+
+    def test_url_output(self):
+        URL = "http://example.com/pub/calendars/jsmith/mytime.ics"
+        e = Event(name="Name", url=URL)
+        eq = """BEGIN:VEVENT
+SUMMARY:Name
+URL:http://example.com/pub/calendars/jsmith/mytime.ics
 END:VEVENT"""
         self.assertEqual(str(e), eq)

--- a/tests/fixture.py
+++ b/tests/fixture.py
@@ -197,6 +197,18 @@ END:VEVENT
 END:VCALENDAR
 """
 
+# Event with URL
+cal16 = u"""
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+SUMMARY:Hello World
+DTSTART;TZID=Europe/Berlin:20120608T202500
+DTEND;TZID=Europe/Berlin:20120608T212500
+URL:http://example.com/pub/calendars/jsmith/mytime.ics
+END:VEVENT
+END:VCALENDAR
+"""
+
 unfolded_cal2 = [
     'BEGIN:VCALENDAR',
     'BEGIN:VEVENT',

--- a/tests/fixture.py
+++ b/tests/fixture.py
@@ -200,12 +200,17 @@ END:VCALENDAR
 # Event with URL
 cal16 = u"""
 BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.9//EN
+
 BEGIN:VEVENT
-SUMMARY:Hello World
+SUMMARY:Hello, \\n World\\; This is a backslash : \\\\ and another new \\N line
 DTSTART;TZID=Europe/Berlin:20120608T202500
 DTEND;TZID=Europe/Berlin:20120608T212500
+LOCATION:MUC
 URL:http://example.com/pub/calendars/jsmith/mytime.ics
 END:VEVENT
+
 END:VCALENDAR
 """
 

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -23,7 +23,7 @@ class TestParse(unittest.TestCase):
         self.assertTrue(isinstance(cal, Container))
         self.assertEqual('VERSION', cal[0].name)
         self.assertEqual('2.0', cal[0].value)
-        self.assertEqual(cal5.strip(), str(cal).strip())
+        self.assertEqual(cal5.strip().splitlines(), str(cal).strip().splitlines())
 
     def test_one_line(self):
         ics = 'DTSTART;TZID=Europe/Brussels:20131029T103000'


### PR DESCRIPTION
This pull request adds a thing and fixes many little details.

- Added support for URLs to Event.
- Fixes according to RFC5545:
    + [Lines are separated by CRLF (`\r\n`)](https://tools.ietf.org/html/rfc5545#section-3.1). Tests had to be adapted,  `str.split('\n')` is changed to the more generic `str.splitlines()`
    + [names of properties etc. are case-insensitive](https://tools.ietf.org/html/rfc5545#page-11). So in `ContentLine.__init__` `name` is uppercased for consistency and easier comparing. Some tests had to be adapted.
- PEP8 Fixes:
    + assigning lambdas to a variable is discouraged, (In eventlist.py there are a lot of these assignments left. I didn't work through this code yet.)
    + formating issues.
- Other fixes:
    + Use `str.split(splitChar, 1)` where appropriate
    + use `isinstance(foo, string_types)` instead of `isinstance(foo, str)`