### PR TITLE
make all_day more liberal

### DIFF
--- a/ics/event.py
+++ b/ics/event.py
@@ -185,7 +185,7 @@ class Event(Component):
         Return:
             bool: self is an all-day event
         """
-        return self._begin_precision == 'day' and not self.has_end()
+        return self._begin_precision == 'day' and ((not self.has_end()) or self.end - self.begin == timedelta(day=1))
 
     def make_all_day(self):
         """Transforms self to an all-day event.


### PR DESCRIPTION
ownCloud calendar events have an end, even if they are created as "all day". But in that case, the precision of the begin is still "day" and the timedelta between end and begin is exactly one day. So with this fix, the `all_day` property also works for calendars which have an end for an "all day" event, as long as the time delta is exactly one day and the begin precision is still "day".