### PR TITLE
Use shorthand DTSTART;VALUE=DATE:YYYYMMDD for all day events

### DIFF
--- a/ics/event.py
+++ b/ics/event.py
@@ -18,6 +18,7 @@ from .utils import (
     iso_precision,
     get_arrow,
     arrow_to_iso,
+    arrow_date_to_iso,
     uid_gen,
     unescape_string,
     escape_string,
@@ -48,7 +49,7 @@ class Event(Component):
                  created=None,
                  location=None,
                  url=None):
-        """Instanciates a new :class:`ics.event.Event`.
+        """Instantiates a new :class:`ics.event.Event`.
 
         Args:
             name (string)
@@ -78,7 +79,7 @@ class Event(Component):
 
         self.name = name
         self.begin = begin
-        #TODO: DRY [1]
+        # TODO: DRY [1]
         if duration and end:
             raise ValueError(
                 'Event() may not specify an end and a duration \
@@ -392,11 +393,15 @@ def o_created(event, container):
 
 @Event._outputs
 def o_start(event, container):
-    if event.begin:
-        container.append(
-            ContentLine('DTSTART', value=arrow_to_iso(event.begin)))
+    if event.begin and not event.all_day:
+        container.append(ContentLine('DTSTART', value=arrow_to_iso(event.begin)))
 
-    # TODO : take care of precision
+
+@Event._outputs
+def o_all_day(event, container):
+    if event.begin and event.all_day:
+        container.append(ContentLine('DTSTART', params={'VALUE': ('DATE',)},
+                                     value=arrow_date_to_iso(event.begin)))
 
 
 @Event._outputs

--- a/ics/utils.py
+++ b/ics/utils.py
@@ -163,6 +163,13 @@ def arrow_to_iso(instant):
     return instant + 'Z'
 
 
+def arrow_date_to_iso(instant):
+    # date-only for all day events
+    # set to utc, make iso, remove timezone
+    instant = arrow.get(instant.astimezone(tzutc)).format('YYYYMMDD')
+    return instant  # no TZ for all days
+
+
 def uid_gen():
     uid = str(uuid4())
     return "{}@{}.org".format(uid, uid[:4])

--- a/tests/event.py
+++ b/tests/event.py
@@ -190,10 +190,10 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(e.location, "In, every text field")
         self.assertEqual(e.description, "Yes, all of them;")
 
-    def test_escapte_output(self):
+    def test_escape_output(self):
         e = Event()
 
-        e.name = "Hello, with \\ spechial; chars and \n newlines"
+        e.name = "Hello, with \\ special; chars and \n newlines"
         e.location = "Here; too"
         e.description = "Every\nwhere ! Yes, yes !"
         e.created = arrow.Arrow(2013, 1, 1)
@@ -201,7 +201,7 @@ class TestEvent(unittest.TestCase):
 
         eq = CRLF.join(("BEGIN:VEVENT",
                 "DTSTAMP:20130101T000000Z",
-                "SUMMARY:Hello\\, with \\\\ spechial\\; chars and \\n newlines",
+                "SUMMARY:Hello\\, with \\\\ special\\; chars and \\n newlines",
                 "DESCRIPTION:Every\\nwhere ! Yes\\, yes !",
                 "LOCATION:Here\\; too",
                 "UID:empty-uid",
@@ -247,3 +247,15 @@ class TestEvent(unittest.TestCase):
         e3.make_all_day()
         self.assertEqual(e2.begin, e3.begin)
         self.assertEqual(e2.end, e3.end)
+
+    def test_all_day_outputs_dtstart_value_date(self):
+        """All day events should output DTSTART using VALUE=DATE without
+        time and timezone in order to assume the user's current timezone
+
+        refs http://www.kanzaki.com/docs/ical/dtstart.html
+             http://www.kanzaki.com/docs/ical/date.html
+        """
+        e = Event(begin="2015/12/21")
+        e.make_all_day()
+        # no time or tz specifier
+        self.assertIn('DTSTART;VALUE=DATE:20151221', str(e).splitlines())


### PR DESCRIPTION
The current incarnation always appends a timestamp and the `Z` timezone specifier whenever you have an all day event. This means that I end up seeing events from `20151220T190000EST` until `20151220T190000EST` because of my timezone (EST -0500).

This pull request makes sure that anyone who imports the calendar has an all day event in their current timezone instead of 24 hours from UTC.

> **Value Type**
> The default value type is DATE-TIME. The time value MUST be one of the forms defined for the DATE-TIME value type. The value type can be set to a DATE value type.

Fixes #73