### PR TITLE
Adds the ability to specify `default` parameters

### DIFF
--- a/ics/component.py
+++ b/ics/component.py
@@ -13,7 +13,7 @@ from .utils import get_lines
 
 Extractor = namedtuple(
     'Extractor',
-    ['function', 'type', 'required', 'multiple']
+    ['function', 'type', 'required', 'multiple', 'default']
 )
 
 
@@ -39,9 +39,12 @@ class Component(object):
         for extractor in self._EXTRACTORS:
             lines = get_lines(container, extractor.type)
             if not lines and extractor.required:
-                raise ValueError(
-                    'A {} must have at least one {}'
-                    .format(container.name, extractor.type))
+                if extractor.default:
+                    lines = extractor.default
+                else:
+                    raise ValueError(
+                        'A {} must have at least one {}'
+                        .format(container.name, extractor.type))
 
             if not extractor.multiple and len(lines) > 1:
                 raise ValueError(
@@ -59,13 +62,14 @@ class Component(object):
         self._unused = container  # Store unused lines
 
     @classmethod
-    def _extracts(cls, line_type, required=False, multiple=False):
+    def _extracts(cls, line_type, required=False, multiple=False, default=False):
         def decorator(fn):
             extractor = Extractor(
                 function=fn,
                 type=line_type,
                 required=required,
-                multiple=multiple)
+                multiple=multiple,
+                default=default)
             cls._EXTRACTORS.append(extractor)
             return fn
         return decorator

--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -148,7 +148,9 @@ def prodid(calendar, prodid):
     calendar._creator = prodid.value
 
 
-@Calendar._extracts('VERSION', required=True, default=['2.0'])
+__version_default__ = ContentLine(name='VERSION', value='2.0')
+
+@Calendar._extracts('VERSION', required=True, default=__version_default__)
 def version(calendar, line):
     version = line
     # TODO : should take care of minver/maxver

--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -148,7 +148,7 @@ def prodid(calendar, prodid):
     calendar._creator = prodid.value
 
 
-@Calendar._extracts('VERSION', required=True)
+@Calendar._extracts('VERSION', required=True, default=['2.0'])
 def version(calendar, line):
     version = line
     # TODO : should take care of minver/maxver

--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -148,7 +148,8 @@ def prodid(calendar, prodid):
     calendar._creator = prodid.value
 
 
-__version_default__ = ContentLine(name='VERSION', value='2.0')
+__version_default__ = [ContentLine(name='VERSION', value='2.0')]
+
 
 @Calendar._extracts('VERSION', required=True, default=__version_default__)
 def version(calendar, line):


### PR DESCRIPTION
This PR adds the ability to specify the default parameters in `@Calendar._extracts` decorator.
If the `required` param is specified but not found, it allows to gracefully assume a default value.

#### Why?
Because I have encountered that a few iCal files have missing `VERSION` key. Rather than raising a TypeError, it makes more sense to allow this.

I'm not sure if this should be a feature, though -- since I only have one anecdotal evidence, so feel free to discuss.

Thanks!
