### PR TITLE
Fix some bugs

### DIFF
--- a/ics/event.py
+++ b/ics/event.py
@@ -142,10 +142,7 @@ class Event(Component):
             # return the beginning + duration
             return self.begin + self._duration
         elif self._end_time:  # if end is time defined
-            if self.all_day:
-                return self._end_time + timedelta(days=1)
-            else:
-                return self._end_time
+            return self._end_time
         elif self._begin:  # if end is not defined
             if self.all_day:
                 return self._begin + timedelta(days=1)
@@ -359,6 +356,8 @@ def end(event, line):
         tz_dict = event._classmethod_kwargs['tz']
         event._end_time = iso_to_arrow(line, tz_dict)
         # one could also save the end_precision to check that if begin_precision is day, end_precision also is
+        #if iso_precision(line.value) == 'day':
+        #    event.make_all_day()
 
 
 @Event._extracts('SUMMARY')
@@ -441,7 +440,11 @@ def o_duration(event, container):
 @Event._outputs
 def o_end(event, container):
     if event.begin and event._end_time:
-        container.append(ContentLine('DTEND', value=arrow_to_iso(event.end)))
+        if event.all_day:
+            container.append(ContentLine('DTEND', params={'VALUE': ('DATE',)},
+                                         value = arrow_date_to_iso(event.end)))
+        else:
+            container.append(ContentLine('DTEND', value=arrow_to_iso(event.end)))
 
 
 @Event._outputs

--- a/ics/timeline.py
+++ b/ics/timeline.py
@@ -57,9 +57,7 @@ class Timeline(object):
             stop : (Arrow object)
         """
         for event in self:
-            if ((start <= event.begin <= stop # if start is between the bonds
-            or start <= event.end <= stop) # or stop is between the bonds
-            or event.begin <= start and event.end >= stop): # or event is a superset of [start,stop]
+            if event.begin < stop and event.end > start:
                 yield event
 
     def start_after(self, instant):

--- a/ics/utils.py
+++ b/ics/utils.py
@@ -17,9 +17,10 @@ tzutc = arrow.utcnow().tzinfo
 tzlocal = gettz('localtime')
 
 def remove_x(container):
+    """Remove non-standard (start with X-) and SEQUENCE lines"""
     for i in reversed(range(len(container))):
         item = container[i]
-        if item.name.startswith('X-'):
+        if item.name.startswith('X-') or item.name == "SEQUENCE":
             del container[i]
 
 

--- a/ics/utils.py
+++ b/ics/utils.py
@@ -11,13 +11,10 @@ from uuid import uuid4
 from dateutil.tz import gettz
 import arrow
 import re
-
 from . import parse
 
 tzutc = arrow.utcnow().tzinfo
-
-tzutc = arrow.utcnow().tzinfo
-
+tzlocal = gettz('localtime')
 
 def remove_x(container):
     for i in reversed(range(len(container))):
@@ -36,8 +33,8 @@ def iso_to_arrow(time_container, available_tz={}):
     # TODO : see if timezone is registered as a VTIMEZONE
     if tz_list and len(tz_list) > 0:
         tz = tz_list[0]
-    else:
-        tz = None
+    else: # Floating event; use local time
+        tz = 'localtime'
     if ('T' not in time_container.value) and \
             'DATE' in time_container.params.get('VALUE', []):
         val = time_container.value + 'T0000'
@@ -168,7 +165,7 @@ def arrow_to_iso(instant):
 def arrow_date_to_iso(instant):
     # date-only for all day events
     # set to utc, make iso, remove timezone
-    instant = arrow.get(instant.astimezone(tzutc)).format('YYYYMMDD')
+    instant = arrow.get(instant.astimezone(tzlocal)).format('YYYYMMDD')
     return instant  # no TZ for all days
 
 


### PR DESCRIPTION
There are two patches in this pull request.  The first fixes all-day events, by allocating the local timezone to them (otherwise, filtering an event list by .today() may miss an all day event for today, if UTC today doesn't overlap local today); the second elides SEQUENCE lines, because the parser can;t cope with them.