### PR TITLE
Reference paramstr instead of line in ParseError

### DIFF
--- a/ics/parse.py
+++ b/ics/parse.py
@@ -76,7 +76,7 @@ class ContentLine:
         params = {}
         for paramstr in params_strings:
             if '=' not in paramstr:
-                raise ParseError("No '=' in line '{}'".format(line))
+                raise ParseError("No '=' in line '{}'".format(paramstr))
             pname, pvals = paramstr.split('=', 1)
             params[pname] = pvals.split(',')
         return cls(name, params, value)


### PR DESCRIPTION
ParseError is raised when '=' is not in paramstr.
But the error message that's returned says '=' is not in line (not paramstr).