### PR TITLE
Add instead of append

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Quickstart
     e = Event()
     e.name = "My cool event"
     e.begin = '20140101 00:00:00'
-    c.add.append(e)
+    c.add.add(e)
     c.events
     # [<Event 'My cool event' begin:2014-01-01 00:00:00 end:2014-01-01 00:00:01>]
     with open('my.ics', 'w') as my_file:


### PR DESCRIPTION
In README.rst under Quickstart, the guide uses append instead of add on a set objects. Sets cannot be appended