### PR TITLE
events/todos: use set not list

### DIFF
--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -35,8 +35,8 @@ class Calendar(Component):
 
         Args:
             imports (string or list of lines/strings): data to be imported into the Calendar(),
-            events (list of Event): :class:`ics.event.Event`s to be added to the calendar
-            todos (list of Todo): :class:`ics.event.Todo`s to be added to the calendar
+            events (set of Event): :class:`ics.event.Event`s to be added to the calendar
+            todos (set of Todo): :class:`ics.event.Todo`s to be added to the calendar
             creator (string): uid of the creator program.
 
         If `imports` is specified, every other argument will be ignored.
@@ -203,7 +203,7 @@ def events(calendar, lines):
     # timezones list
     def event_factory(x):
         return Event._from_container(x, tz=calendar._timezones)
-    calendar.events = list(map(event_factory, lines))
+    calendar.events = set(map(event_factory, lines))
 
 
 @Calendar._extracts('VTODO', multiple=True)
@@ -212,7 +212,7 @@ def todos(calendar, lines):
     # timezones list
     def todo_factory(x):
         return Todo._from_container(x, tz=calendar._timezones)
-    calendar.todos = list(map(todo_factory, lines))
+    calendar.todos = set(map(todo_factory, lines))
 
 
 # -------------------

--- a/tests/alarm.py
+++ b/tests/alarm.py
@@ -125,7 +125,7 @@ class TestDisplayAlarm(unittest.TestCase):
 
     def test_alarm_without_repeat_extraction(self):
         c = Calendar(cal21)
-        a = c.events[0].alarms[0]
+        a = next(iter(c.events)).alarms[0]
         self.assertEqual(a.trigger, timedelta(hours=1))
         self.assertIsNone(a.repeat)
         self.assertIsNone(a.duration)
@@ -133,7 +133,7 @@ class TestDisplayAlarm(unittest.TestCase):
 
     def test_alarm_with_repeat_extraction(self):
         c = Calendar(cal22)
-        a = c.events[0].alarms[0]
+        a = next(iter(c.events)).alarms[0]
         self.assertEqual(a.trigger, timedelta(hours=1))
         self.assertEqual(a.repeat, 2)
         self.assertEqual(a.duration, timedelta(minutes=10))
@@ -141,7 +141,7 @@ class TestDisplayAlarm(unittest.TestCase):
 
     def test_alarm_without_repeat_datetime_trigger_extraction(self):
         c = Calendar(cal23)
-        a = c.events[0].alarms[0]
+        a = next(iter(c.events)).alarms[0]
 
         alarm_time = datetime(year=2016, month=1, day=1, hour=0, minute=0, second=0)
         self.assertEqual(a.trigger, arrow.get(alarm_time))
@@ -189,7 +189,7 @@ class TestAudioAlarm(unittest.TestCase):
 
     def test_alarm_without_attach_extraction(self):
         c = Calendar(cal24)
-        a = c.events[0].alarms[0]
+        a = next(iter(c.events)).alarms[0]
         alarm_time = datetime(year=2016, month=1, day=1, hour=0, minute=0, second=0)
 
         self.assertEqual(a.action, 'AUDIO')
@@ -201,7 +201,7 @@ class TestAudioAlarm(unittest.TestCase):
 
     def test_alarm_with_attach_extraction(self):
         c = Calendar(cal25)
-        a = c.events[0].alarms[0]
+        a = next(iter(c.events)).alarms[0]
         alarm_time = datetime(year=2016, month=1, day=1, hour=0, minute=0, second=0)
 
         self.assertEqual(a.action, 'AUDIO')

--- a/tests/calendar.py
+++ b/tests/calendar.py
@@ -206,12 +206,12 @@ class TestCalendar(unittest.TestCase):
         c = Calendar(cal1)
         self.assertEqual(c.creator, '-//Apple Inc.//Mac OS X 10.9//EN')
         self.assertEqual(c.method, 'PUBLISH')
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertFalse(e.all_day)
         self.assertEqual(arrow.get(2013, 10, 29, 9, 30), e.begin)
         self.assertEqual(arrow.get(2013, 10, 29, 10, 30), e.end)
         self.assertEqual(1, len(c.events))
-        t = c.todos[0]
+        t = next(iter(c.todos))
         self.assertEqual(t.dtstamp, arrow.get(2018, 2, 18, 15, 47))
         self.assertEqual(t.uid, 'Uid')
         self.assertEqual(len(c.todos), 1)

--- a/tests/event.py
+++ b/tests/event.py
@@ -40,7 +40,7 @@ class TestEvent(unittest.TestCase):
 
     def test_event_with_duration(self):
         c = Calendar(cal12)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e._duration, td(1, 3600))
         self.assertEqual(e.end - e.begin, td(1, 3600))
 
@@ -182,12 +182,12 @@ class TestEvent(unittest.TestCase):
 
     def test_unescape_summary(self):
         c = Calendar(cal15)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e.name, "Hello, \n World; This is a backslash : \\ and another new \n line")
 
     def test_unescapte_texts(self):
         c = Calendar(cal17)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e.name, "Some special ; chars")
         self.assertEqual(e.location, "In, every text field")
         self.assertEqual(e.description, "Yes, all of them;")
@@ -213,7 +213,7 @@ class TestEvent(unittest.TestCase):
 
     def test_url_input(self):
         c = Calendar(cal16)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e.url, "http://example.com/pub/calendars/jsmith/mytime.ics")
 
     def test_url_output(self):
@@ -223,7 +223,7 @@ class TestEvent(unittest.TestCase):
 
     def test_status_input(self):
         c = Calendar(cal16)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e.status, "CONFIRMED")
 
     def test_status_output(self):
@@ -233,7 +233,7 @@ class TestEvent(unittest.TestCase):
 
     def test_category_input(self):
         c = Calendar(cal16)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertIn("Simple Category", e.categories)
         self.assertIn("My \"Quoted\" Category", e.categories)
         self.assertIn("Category, with comma", e.categories)
@@ -245,23 +245,23 @@ class TestEvent(unittest.TestCase):
 
     def test_all_day_with_end(self):
         c = Calendar(cal20)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertTrue(e.all_day)
 
     def test_not_all_day(self):
         c = Calendar(cal16)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertFalse(e.all_day)
 
     def test_all_day_duration(self):
         c = Calendar(cal20)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertTrue(e.all_day)
         self.assertEqual(e.duration, td(days=3))
 
     def test_make_all_day_idempotence(self):
         c = Calendar(cal18)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertFalse(e.all_day)
         e2 = e.clone()
         e2.make_all_day()
@@ -287,7 +287,7 @@ class TestEvent(unittest.TestCase):
 
     def test_transparent_input(self):
         c = Calendar(cal19)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e.transparent, False)
 
     def test_transparent_output(self):
@@ -297,7 +297,7 @@ class TestEvent(unittest.TestCase):
 
     def test_default_transparent_input(self):
         c = Calendar(cal18)
-        e = c.events[0]
+        e = next(iter(c.events))
         self.assertEqual(e.transparent, False)
 
     def test_default_transparent_output(self):

--- a/tests/todo.py
+++ b/tests/todo.py
@@ -313,7 +313,7 @@ class TestTodo(unittest.TestCase):
 
     def test_extract(self):
         c = Calendar(cal27)
-        t = c.todos[0]
+        t = next(iter(c.todos))
         self.assertEqual(t.dtstamp, arrow.get('20180218T154700Z'))
         self.assertEqual(t.uid, 'Uid')
         self.assertEqual(t.completed, arrow.get('20180418T150001Z+00:00'))
@@ -330,7 +330,7 @@ class TestTodo(unittest.TestCase):
 
     def test_extract_due(self):
         c = Calendar(cal28)
-        t = c.todos[0]
+        t = next(iter(c.todos))
         self.assertEqual(t.due, arrow.get('20180218T164800Z+00:00'))
 
     def test_extract_due_error_duration(self):
@@ -343,7 +343,7 @@ class TestTodo(unittest.TestCase):
 
     def test_output(self):
         c = Calendar(cal27)
-        t = c.todos[0]
+        t = next(iter(c.todos))
 
         test_str = CRLF.join(("BEGIN:VTODO",
                               "SEQUENCE:0",
@@ -381,7 +381,7 @@ class TestTodo(unittest.TestCase):
 
     def test_unescape_texts(self):
         c = Calendar(cal31)
-        t = c.todos[0]
+        t = next(iter(c.todos))
         self.assertEqual(t.name, "Hello, \n World; This is a backslash : \\ and another new \n line")
         self.assertEqual(t.location, "In, every text field")
         self.assertEqual(t.description, "Yes, all of them;")


### PR DESCRIPTION
Some import and test code were using a list instead of a set.