### PR TITLE
Support VALARM of ACTION:NONE

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Other contributors, listed alphabetically, are:
 * `@rkeilty <https://github.com/rkeilty>`_
 * `@tgamauf <https://github.com/tgamauf>`_
 * `@Trii <https://github.com/Trii>`_
+* `@zagnut007 <https://github.com/zagnut007>`_
 
 Many thanks for your contributions!
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Ics.py changelog
 **************
 
  - Drop support for Python 2.7 and 3.3.
+ - Fixed NONE type support for Alarms
 
 **************
 0.4

--- a/ics/alarm.py
+++ b/ics/alarm.py
@@ -32,6 +32,8 @@ class AlarmFactory(object):
             return DisplayAlarm
         elif action_type == 'AUDIO':
             return AudioAlarm
+        elif action_type == 'NONE':
+            return None
 
         raise ValueError('Invalid alarm action')
 

--- a/ics/event.py
+++ b/ics/event.py
@@ -504,7 +504,8 @@ def uid(event, line):
 def alarms(event, lines):
     def alarm_factory(x):
         af = AlarmFactory.get_type_from_container(x)
-        return af._from_container(x)
+        if af != None:
+            return af._from_container(x)
     event.alarms = list(map(alarm_factory, lines))
 
 

--- a/ics/event.py
+++ b/ics/event.py
@@ -504,7 +504,7 @@ def uid(event, line):
 def alarms(event, lines):
     def alarm_factory(x):
         af = AlarmFactory.get_type_from_container(x)
-        if af != None:
+        if af is not None:
             return af._from_container(x)
     event.alarms = list(map(alarm_factory, lines))
 


### PR DESCRIPTION
It looks like Google ICS files may include a VALARM action of None which throws an error. Although this type isn't mentioned in the RFC that I could find, I think ignoring these alarms is valid based on the action type and should throw an error given the popularity of Google Calendar.

This addresses: https://github.com/C4ptainCrunch/ics.py/issues/127