### PR TITLE
Fix all-day events lasting multiple days

### DIFF
--- a/ics/event.py
+++ b/ics/event.py
@@ -547,7 +547,9 @@ def o_all_day(event, container):
     if event.begin and event.all_day:
         container.append(ContentLine('DTSTART', params={'VALUE': ('DATE',)},
                                      value=arrow_date_to_iso(event.begin)))
-
+        if event._end_time:
+            container.append(ContentLine('DTEND', params={'VALUE': ('DATE',)},
+                                         value=arrow_date_to_iso(event.end)))
 
 @Event._outputs
 def o_duration(event, container):
@@ -559,7 +561,7 @@ def o_duration(event, container):
 
 @Event._outputs
 def o_end(event, container):
-    if event.begin and event._end_time:
+    if event.begin and event._end_time and not event.all_day:
         container.append(ContentLine('DTEND', value=arrow_to_iso(event.end)))
 
 

--- a/ics/event.py
+++ b/ics/event.py
@@ -551,6 +551,7 @@ def o_all_day(event, container):
             container.append(ContentLine('DTEND', params={'VALUE': ('DATE',)},
                                          value=arrow_date_to_iso(event.end)))
 
+
 @Event._outputs
 def o_duration(event, container):
     # TODO : DURATION


### PR DESCRIPTION
Before this patch, all-day that lasted multiple days had a wrong `DTEND` field: it kept hour/minute/second information, which is a problem for some calendar client like khal and ICSdroid.

This patch fixes this issue.