### PR TITLE
requirements: Lock arrow version to >0.4.2

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ Ics.py is written and maintained by Nikita Marchant <nikita.marchant@gmail.com>.
 Other contributors, listed alphabetically, are:
 
 * `@aureooms <https://github.com/aureooms>`_
+* `@chauffer <https://github.com/chauffer>`_
 * `@ConnyOnny <https://github.com/ConnyOnny>`_
 * `@ConnyOnny <https://github.com/ConnyOnny>`_
 * `@davidjb <https://github.com/davidjb>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Ics.py changelog
 **************
 
  - Drop support for Python 2.7 and 3.3.
+ - requirements: Lock arrow version to >0.4.2
 
 **************
 0.4

--- a/ics/utils.py
+++ b/ics/utils.py
@@ -49,7 +49,7 @@ def iso_to_arrow(time_container, available_tz={}):
             selected_tz = available_tz.get(tz, 'UTC')
         return arrow.get(naive, selected_tz)
     else:
-        return arrow.get(val)
+        return arrow.get(val, 'YYYYMMDDTHHmmZ')
 
     # TODO : support floating (ie not bound to any time zone) times (cf
     # http://www.kanzaki.com/docs/ical/dateTime.html)
@@ -154,7 +154,10 @@ def get_arrow(value):
     elif isinstance(value, dict):
         return arrow.get(**value)
     else:
-        return arrow.get(value)
+        try:
+            return arrow.get(value, 'YYYYMMDDTHHmmZ')
+        except arrow.parser.ParserError:
+            return arrow.get(value)
 
 
 def arrow_to_iso(instant):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil
-arrow==0.4.2
+arrow>=0.4.2
 six>1.5

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,12 @@ import sys
 
 from meta import __version__, __title__, __license__, __author__
 
+with open("requirements.txt") as f:
+    install_requires = [line for line in f if line and line[0] not in "#-"]
+
+with open("dev/requirements-test.txt") as f:
+    tests_require = [line for line in f if line and line[0] not in "#-"]
+
 
 class PyTest(TestCommand):
 
@@ -58,16 +64,12 @@ setup(
     url='http://github.com/C4ptainCrunch/ics.py',
     author=__author__,
     author_email='nikita.marchant@gmail.com',
-    install_requires=[
-        "python-dateutil",
-        "arrow==0.4.2",
-        "six>1.5",
-    ],
+    install_requires=install_requires,
     license=__license__,
     packages=['ics'],
     include_package_data=True,
     cmdclass={'test': PyTest},
-    tests_require=['pytest', 'pytest-cov', 'pytest-flakes', 'pytest-pep8'],
+    tests_require=tests_require,
     test_suite="py.test",
     zip_safe=False,
 )


### PR DESCRIPTION
Tested with 0.11.2. Necessary due to granularity parameter in
humanize()