### PR TITLE
Improve TRIGGER DURATION parsing logic

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Other contributors, listed alphabetically, are:
 * `@rkeilty <https://github.com/rkeilty>`_
 * `@tgamauf <https://github.com/tgamauf>`_
 * `@Trii <https://github.com/Trii>`_
+* `@jessejoe <https://github.com/jessejoe>`_
 
 Many thanks for your contributions!
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Ics.py changelog
 **************
 
  - Drop support for Python 2.7 and 3.3.
+ - Improve TRIGGER DURATION parsing logic
 
 **************
 0.4

--- a/ics/alarm.py
+++ b/ics/alarm.py
@@ -180,7 +180,7 @@ class Alarm(Component):
 # ------------------
 @Alarm._extracts('TRIGGER', required=True)
 def trigger(alarm, line):
-    if not line.params:
+    if not line.params or 'DURATION' in line.params.get('VALUE', ''):
         alarm.trigger = parse_duration(line.value[1:])
     else:
         if len(line.params) > 1:


### PR DESCRIPTION
TRIGGER DURATIONs can also take the form `TRIGGER;VALUE=DURATION:-PT30M`. The existing logic only accounts for `TRIGGER:-PT30M`.

This can be tested with any of the NHL ical schedules from this season, e.g. https://www.stanza.co/api/schedules/nhl-sabres/nhl-sabres.ics .

Before:
```python
In [2]: cal = ics.Calendar(requests.get('https://www.stanza.co/api/schedules/nhl-sabres/nhl-sabres.ics').text)

ParserError: Could not match input to any of ['YYYY-MM-DDTHH:mm']
```

After:
```python
In [2]: cal = ics.Calendar(requests.get('https://www.stanza.co/api/schedules/nhl-sabres/nhl-sabres.ics').text)

In [3]: cal.events[0].alarms[0].trigger
Out[3]: datetime.timedelta(0, 1800)
```