### PR TITLE
Make Alarm hashable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Other contributors, listed alphabetically, are:
 * `@jammon <https://github.com/jammon>`_
 * `@mrmadcow <https://github.com/mrmadcow>`_
 * `@perette <https://github.com/perette>`_
+* `@Philiptpp <https://github.com/Philiptpp>`_
 * `@prashnts <https://github.com/prashnts>`_
 * `@rkeilty <https://github.com/rkeilty>`_
 * `@tgamauf <https://github.com/tgamauf>`_

--- a/ics/alarm.py
+++ b/ics/alarm.py
@@ -157,6 +157,9 @@ class Alarm(Component):
 
         return '<{0}>'.format(value)
 
+    def __hash__(self):
+        return hash(repr(self))
+
     def __ne__(self, other):
         return not self.__eq__(other)
 


### PR DESCRIPTION
Add __hash__ method to the Alarm class to make it hashable
in order to be able to add an Alarm list to the Events.alarms set.

Fixes #130 