### PR TITLE
Add priority and due date and time in events properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ doc/_build/*
 .coverage
 htmlcov
 /.pytest_cache/
+
+# PyCharm
+.idea*

--- a/ics/event.py
+++ b/ics/event.py
@@ -40,11 +40,6 @@ class Event(Component):
     _EXTRACTORS = []
     _OUTPUTS = []
 
-    _HIGHER_PRIORITY = 4
-    _HIGH_PRIORITY = 3
-    _MEDIUM_PRIORITY = 2
-    _LOW_PRIORITY = 1
-
     def __init__(self,
                  name=None,
                  begin=None,
@@ -59,7 +54,7 @@ class Event(Component):
                  alarms=None,
                  categories=None,
                  status=None,
-                 priority=_LOW_PRIORITY,
+                 priority=0,
                  due=None
                  ):
         """Instantiates a new :class:`ics.event.Event`.
@@ -90,7 +85,7 @@ class Event(Component):
         self._end_time = None
         self._begin = None
         self._begin_precision = None
-        self._priority = self._LOW_PRIORITY
+        self._priority = None
         self._due = None
         self._due_precision = None
 

--- a/ics/event.py
+++ b/ics/event.py
@@ -254,7 +254,7 @@ class Event(Component):
         if value and self._end_time and value < self._end_time:
             raise ValueError('Due must be the or after the end')
         self._due = value
-        self._due_precision = 'minute'
+        self._due_precision = 'second'
 
     @property
     def all_day(self):

--- a/ics/event.py
+++ b/ics/event.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals, absolute_import
 
-from six import StringIO, string_types, text_type, integer_types
+# from six import StringIO, string_types, text_type, integer_types
 
 import arrow
 import copy
@@ -87,7 +87,6 @@ class Event(Component):
         self._begin_precision = None
         self._priority = None
         self._due = None
-        self._due_precision = None
 
         self.uid = uid_gen() if not uid else uid
         self.description = description
@@ -249,7 +248,6 @@ class Event(Component):
         if value and self._end_time and value < self._end_time:
             raise ValueError('Due must be the or after the end')
         self._due = value
-        self._due_precision = 'second'
 
     @property
     def all_day(self):
@@ -572,18 +570,17 @@ def categories(event, line):
 
 
 @Event._extracts('PRIORITY')
-def status(event, line):
+def priority(event, line):
     if line:
         event.priority = line.value
 
 
 @Event._extracts('DTDUE')
-def start(event, line):
+def due(event, line):
     if line:
         # get the dict of vtimezones passed to the classmethod
         tz_dict = event._classmethod_kwargs['tz']
         event.due = iso_to_arrow(line, tz_dict)
-        event._due_precision = iso_precision(line.value)
 
 
 # -------------------


### PR DESCRIPTION
This properties could be useful for some applications. The existence of such properties doesn't affect the package, since it is ignored by the parser if "PRIORITY" and "DTDUE" are not specified in .ics or.ical files.