### PR TITLE
Bugfix in Event constructor self.organizer is None

### DIFF
--- a/ics/event.py
+++ b/ics/event.py
@@ -91,7 +91,7 @@ class Event(Component):
         self._status: Optional[str] = None
         self._classification: Optional[str] = None
 
-        self.organizer: Optional[str] = None
+        self.organizer: Optional[Organizer] = organizer
         self.uid: str = uid_gen() if not uid else uid
         self.description: Optional[str] = description
         self.created: Optional[ArrowLike] = get_arrow(created)


### PR DESCRIPTION
Hi, 👋

Thank for this great project.

With this PR I am proposing to fix : 

  - Even when passing an Organizer to Event object __init__, it is not set and therefor not serialized.

What can cause a missing Organizer in ics ?

  - For ex. it can make Outlook believe that there is not from field in a email. (Weird, isn't it ?)

Thank.