### PR TITLE
use last compatible tatsu 4.x before python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 python-dateutil
 arrow>=0.11,<0.15
 six>1.5
-tatsu>4.2
+tatsu>4.2,<5 ; python_version < '3.8'
+tatsu>4.2 ; python_version >= '3.8'


### PR DESCRIPTION
fixes #221