### PR TITLE
Revert "Improve all-day event handling." (#155/#204)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,11 +8,8 @@ Ics.py changelog
 **************
 
 Major changes:
- - `make_all_day()` changes:
-  - If an event has a duration instead of an end time, make_all_day now rounds
-    the duration up to the next 24-hour interval. If it's already an even day,
-    the duration is unchanged.  
 
+Minor changes:
 
 **************
 0.6

--- a/ics/event.py
+++ b/ics/event.py
@@ -148,20 +148,16 @@ class Event(Component):
         |  May be set to anything that :func:`Arrow.get` understands.
         |  If an end is defined (not a duration), .begin must not
             be set to a superior value.
-        |  For all-day events, the time is truncated to midnight when set.
         """
         return self._begin
 
     @begin.setter
     def begin(self, value: ArrowLike):
         value = get_arrow(value)
-        precision = 'day' if self.all_day else 'second'
-        if value is not None:
-            value = value.floor(precision)
         if value and self._end_time and value > self._end_time:
             raise ValueError('Begin must be before end')
         self._begin = value
-        self._begin_precision = precision
+        self._begin_precision = 'second'
 
     @property
     def end(self) -> Arrow:
@@ -174,15 +170,11 @@ class Event(Component):
         |  Setting to None will have unexpected behavior if
             begin is not None.
         |  Must not be set to an inferior value than self.begin.
-        |  When setting end time for for all-day events, if the end time
-            is midnight, that day is not included.  Otherwise, the end is
-            rounded up to midnight the next day, including the full day.
-            Note that rounding is different from :func:`make_all_day`.
         """
 
         if self._duration:  # if end is duration defined
             # return the beginning + duration
-            return None if self._begin is None else self.begin + self._duration
+            return self.begin + self._duration
         elif self._end_time:  # if end is time defined
             if self.all_day:
                 return self._end_time
@@ -200,25 +192,12 @@ class Event(Component):
     @end.setter
     def end(self, value: ArrowLike):
         value = get_arrow(value)
-        precision = 'day' if self.all_day else 'second'
-        if value is not None:
-            floored_value = value.floor(precision)
-            if precision == 'day' and value != floored_value:
-                value = floored_value + timedelta(days=1)
-            else:
-                value = floored_value
         if value and self._begin and value < self._begin:
             raise ValueError('End must be after begin')
 
         self._end_time = value
         if value:
             self._duration = None
-            self._begin_precision = precision
-
-    def _timedelta_ceiling(self, value, precision):
-        if precision != 'day' or (value.seconds == 0 and value.microseconds == 0):
-            return value
-        return timedelta(days=value.days + 1)
 
     @property
     def duration(self) -> Optional[timedelta]:
@@ -229,7 +208,6 @@ class Event(Component):
         |  May be set with a dict ({"days":2, "hours":6}).
         |  If set to a non null value, removes any already
             existing end time.
-        |  Duration of an all-day event is rounded up to a full day.
         """
         if self._duration:
             return self._duration
@@ -250,9 +228,6 @@ class Event(Component):
             value = timedelta(value)
 
         if value:
-            if value < timedelta(0):
-                raise ValueError('Duration must be positive')
-            value = self._timedelta_ceiling(value, self._begin_precision)
             self._end_time = None
 
         self._duration = value
@@ -287,51 +262,27 @@ class Event(Component):
         # the event may have an end, also given in 'day' precision
         return self._begin_precision == 'day'
 
-    def make_all_day(self, become_all_day=True):
-        """Transforms self to an all-day event or a time-based event.
+    def make_all_day(self) -> None:
+        """Transforms self to an all-day event.
 
-        |  If become_all_day is False, the event is set to a time-based
-            event.  Any rounding performed when the event was made all-day
-            is *not* undone.
-        |  Otherwise:
-        |  The event will span all the days from the begin to *and including*
-            the end day.  For example, assume begin = 2018-01-01 10:37,
-            end = 2018-01-02 14:44.  After make_all_day, begin = 2018-01-01
-            [00:00], end = 2018-01-03 [00:00], and duration = 2 days.
-        |  If duration is used instead of the end time, it is rounded up to an
-            even day.  2 days remains 2 days, but 2 days and one second becomes 3 days.
-        |  If neither duration not end are set, a duration of one day is implied.
-        |  If self is already all-day, it is unchanged.
+        The event will span all the days from the begin to the end day.
         """
-        if not become_all_day:
-            self._begin_precision = 'second'
-            return
-
         if self.all_day:
             # Do nothing if we already are a all day event
             return
 
         begin_day = self.begin.floor('day')
+        end_day = self.end.floor('day')
+
         self._begin = begin_day
 
-        if self._end_time is not None:
-            end_day = self.end.floor('day')
-
-            # for a one day event, we don't need a _end_time
-            if begin_day == end_day:
-                self._end_time = None
-            else:
-                self._end_time = end_day + timedelta(days=1)
-            self._duration = None
-        elif self._duration is not None:
-            duration = self._timedelta_ceiling(self._duration, 'day')
-            # for a one day event, we don't need a duration
-            if duration == timedelta(days=1):
-                self._duration = None
-            else:
-                self._duration = duration
+        # for a one day event, we don't need a _end_time
+        if begin_day == end_day:
             self._end_time = None
+        else:
+            self._end_time = end_day + timedelta(days=1)
 
+        self._duration = None
         self._begin_precision = 'day'
 
     @property

--- a/tests/event.py
+++ b/tests/event.py
@@ -1,4 +1,3 @@
-
 import unittest
 from datetime import datetime as dt
 from datetime import timedelta as td
@@ -68,7 +67,6 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(e._end_time, None)
         self.assertEqual(e._duration, None)
 
-    # Check all-day without an end time.
     def test_make_all_day2(self):
         e = Event(begin="1993/05/24")
         begin = arrow.get("1993/05/24")
@@ -87,95 +85,6 @@ class TestEvent(unittest.TestCase):
 
         self.assertEqual(e._end_time, None)
         self.assertEqual(e.end, arrow.get("1993/05/25"))
-
-    # Check all-day with an end time.
-    def test_make_all_day3(self):
-        begin = arrow.get("2018-12-23")
-        end = arrow.get("2018-12-25")
-        e = Event(begin=begin, end=end)
-
-        self.assertEqual(e._begin, begin)
-        self.assertEqual(e.begin, begin)
-
-        self.assertEqual(e._end_time, end)
-        self.assertEqual(e.end, end)
-
-        e.make_all_day()
-
-        self.assertEqual(e._begin, arrow.get("2018-12-23"))
-        self.assertEqual(e.begin, arrow.get("2018-12-23"))
-        self.assertEqual(e._begin_precision, "day")
-
-        self.assertEqual(e._end_time, arrow.get("2018-12-26"))
-        self.assertEqual(e.end, arrow.get("2018-12-26"))
-
-    # Check that adding an all-day end time works
-    def test_make_all_day4(self):
-        e = Event(begin="2018-12-23 14:35")
-        begin = arrow.get("2018-12-23 14:35")
-
-        self.assertEqual(e._begin, begin)
-        self.assertEqual(e.begin, begin)
-
-        self.assertEqual(e._end_time, None)
-        self.assertEqual(e.end, begin)
-
-        e.make_all_day()
-
-        self.assertEqual(e._begin, arrow.get("2018-12-23"))
-        self.assertEqual(e.begin, arrow.get("2018-12-23"))
-        self.assertEqual(e._begin_precision, "day")
-
-        self.assertEqual(e._end_time, None)
-        self.assertEqual(e.end, arrow.get("2018-12-24"))
-
-        e.end = "2018-12-25"
-        self.assertEqual(e._end_time, arrow.get("2018-12-25"))
-        self.assertEqual(e.end, arrow.get("2018-12-25"))
-        self.assertEqual(e._begin_precision, "day")
-        self.assertEqual(e.duration, td(days=2))
-
-        e.end = "2018-12-25 11:02"
-        self.assertEqual(e._end_time, arrow.get("2018-12-26"))
-        self.assertEqual(e.end, arrow.get("2018-12-26"))
-        self.assertEqual(e._begin_precision, "day")
-        self.assertEqual(e.duration, td(days=3))
-
-        self.assertEqual(e._begin, arrow.get("2018-12-23"))
-        self.assertEqual(e.begin, arrow.get("2018-12-23"))
-        self.assertEqual(e._begin_precision, "day")
-
-    # Check that all-day events with durations work
-    def test_make_all_day5(self):
-        e = Event(begin="2018-12-23 14:35", duration=td(days=2, seconds=4*3600))
-        begin = arrow.get("2018-12-23 14:35")
-
-        self.assertEqual(e._begin, begin)
-        self.assertEqual(e.begin, begin)
-
-        self.assertEqual(e.duration, td(days=2, seconds=4*3600))
-        self.assertEqual(e._end_time, None)
-        self.assertEqual(e.end, arrow.get("2018-12-25 18:35"))
-
-        e.make_all_day()
-
-        self.assertEqual(e._begin, arrow.get("2018-12-23"))
-        self.assertEqual(e.begin, arrow.get("2018-12-23"))
-        self.assertEqual(e._begin_precision, "day")
-
-        self.assertEqual(e._end_time, None)
-        self.assertEqual(e.end, arrow.get("2018-12-26"))
-        self.assertEqual(e.duration, td(days=3))
-
-        # When start time is changed, end time should too.
-        e.begin = "2018-12-25"
-        self.assertEqual(e._begin, arrow.get("2018-12-25"))
-        self.assertEqual(e.begin, arrow.get("2018-12-25"))
-        self.assertEqual(e._begin_precision, "day")
-
-        self.assertEqual(e._end_time, None)
-        self.assertEqual(e.end, arrow.get("2018-12-28"))
-        self.assertEqual(e.duration, td(days=3))
 
     def test_init_duration_end(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This reverts commit ed14cde096ad5b50bfa768c1fd32892eba744087.
See discussion here:
https://github.com/C4ptainCrunch/ics.py/pull/222#issuecomment-585215211
We want to only include simple changes in the directly next release and
wait with the complicated all-day and event timestamp handling issues
for the then following dedicated release, which is prepared in
https://github.com/C4ptainCrunch/ics.py/pull/222.